### PR TITLE
Implement translation phase 2

### DIFF
--- a/src/lexer/mod.rs
+++ b/src/lexer/mod.rs
@@ -11,8 +11,6 @@ pub type LexResult = Result<Vec<PToken>, ()>;
 
 /// Runs the Lexer that takes the input source string and produces a Vec<PToken> for later preprocessing
 pub fn lex(session: &Session, input_file: Rc<SourceFile>) -> LexResult {
-    // TODO: Emit warning for attempted nested multi-line comments
-
     let mut tokens = Vec::new();
 
     let source = input_file.src.as_ref().unwrap();
@@ -63,21 +61,19 @@ pub fn lex(session: &Session, input_file: Rc<SourceFile>) -> LexResult {
 
                 had_error = true;
             }
-        } else {
-            if multi_comment_start.is_none() {
-                if token.kind == PTokenKind::ErrorGeneric {
-                    let text = session.span_to_string(&token.into()).unwrap();
+        } else if multi_comment_start.is_none() {
+            if token.kind == PTokenKind::ErrorGeneric {
+                let text = session.span_to_string(&token.into()).unwrap();
 
-                    session
-                        .struct_error(format!("error lexing token `{}`", text))
-                        .span_label(token.into(), "invalid token found")
-                        .emit();
+                session
+                    .struct_error(format!("error lexing token `{}`", text))
+                    .span_label(token.into(), "invalid token found")
+                    .emit();
 
-                    had_error = true;
-                }
-
-                tokens.push(token);
+                had_error = true;
             }
+
+            tokens.push(token);
         }
 
         index += slice.len();

--- a/src/lexer/token.rs
+++ b/src/lexer/token.rs
@@ -66,8 +66,14 @@ pub enum PTokenKind {
     CommentSingle,
 
     /// A multi-line comment
-    #[regex(r"/\*[^*]*\*+(?:[^/*][^*]*\*+)*/")]
-    CommentMulti,
+    #[regex(r"/\*")]
+    CommentMultiStart,
+
+    #[regex(r"\*/")]
+    CommentMultiEnd,
+
+    #[token("\\")]
+    Backslash,
 
     /// Any non-newline whitespace, which we can't skip for the single reason that: preprocessor
     /// operations

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 #![allow(clippy::result_unit_err)]
 pub mod diagnostic;
 pub mod lexer;
+pub mod preprocessor;
 
 #[cfg(test)]
 mod tests {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,7 @@
 use sacc::{
     diagnostic::{session::Session, Handler, HandlerFlags, SourceManager},
     lexer::lex,
+    preprocessor::phase2::phase2,
 };
 use std::{path::Path, process::exit, rc::Rc};
 
@@ -21,9 +22,13 @@ fn main() {
 
     match session.load_file(path) {
         Ok(root_src) => {
+            // Lex tokens from our main source
             if let Ok(tokens) = lex(&session, root_src) {
-                for token in tokens.iter() {
-                    println!("{:?}", token);
+                // Run phase 2 of translation, which removes comments and backslashes and newlines
+                if let Ok(tokens) = phase2(tokens, &session) {
+                    for token in tokens.iter() {
+                        println!("{:?}", token);
+                    }
                 }
             }
         }

--- a/src/preprocessor/mod.rs
+++ b/src/preprocessor/mod.rs
@@ -1,0 +1,1 @@
+pub mod phase2;

--- a/src/preprocessor/phase2.rs
+++ b/src/preprocessor/phase2.rs
@@ -48,13 +48,11 @@ pub fn phase2(tokens: Vec<PToken>, session: &Session) -> Result<Vec<PToken>, ()>
                 has_error = true;
                 backslash = None;
             }
-        } else {
-            if token.kind != PTokenKind::CommentSingle {
-                if token.kind == PTokenKind::Backslash {
-                    backslash = Some(token);
-                } else {
-                    new_tokens.push(token);
-                }
+        } else if token.kind != PTokenKind::CommentSingle {
+            if token.kind == PTokenKind::Backslash {
+                backslash = Some(token);
+            } else {
+                new_tokens.push(token);
             }
         }
     }

--- a/src/preprocessor/phase2.rs
+++ b/src/preprocessor/phase2.rs
@@ -1,0 +1,75 @@
+use crate::{
+    diagnostic::session::Session,
+    lexer::{PToken, PTokenKind},
+};
+
+/// Phase 1 according to the C specification is replacing trigraph sequences. Because of the nature
+/// of preprocessing tokens, and a distaste of looping through every character before it gets to
+/// the lexer, that phase will be postponed as it correctly can be. Therefore phase 2 will come
+/// first.
+///
+/// According to the C specification, phase 2 consists of:
+///
+/// Each instance of a backslash character ( \) immediately followed by a new-line
+/// character is deleted, splicing physical source lines to form logical source lines.
+/// Only the last backslash on any physical source line shall be eligible for being part
+/// of such a splice. A source file that is not empty shall end in a new-line character,
+/// which shall not be immediately preceded by a backslash character before any such
+/// splicing takes place.
+///
+/// Therefore this function removes all newlines following a backslash. Because comments also
+/// have no effect on the code generated from C, they are also stripped here.
+///
+pub fn phase2(tokens: Vec<PToken>, session: &Session) -> Result<Vec<PToken>, ()> {
+    let mut new_tokens = Vec::with_capacity(tokens.capacity());
+
+    let mut backslash: Option<PToken> = None;
+    let mut has_error = false;
+
+    for token in tokens {
+        if backslash.is_some() {
+            if token.kind == PTokenKind::Newline {
+                backslash = None;
+            } else if token.kind == PTokenKind::Whitespace {
+                session
+                    .struct_span_warn(token.into(), "whitespace before newline after `\\`")
+                    .emit();
+            } else {
+                // At this point we don't have to worry about other files being included in the
+                // token stream
+                let s = session.span_to_string(&token.into()).unwrap();
+
+                session
+                    .struct_error(format!("found unexpected token `{}`", s))
+                    .span_label(token.into(), "expected newline after `\\`, found this")
+                    .emit();
+
+                // We can continue to try, just in case they make the same mistake again?
+                has_error = true;
+                backslash = None;
+            }
+        } else {
+            if token.kind != PTokenKind::CommentSingle {
+                if token.kind == PTokenKind::Backslash {
+                    backslash = Some(token);
+                } else {
+                    new_tokens.push(token);
+                }
+            }
+        }
+    }
+
+    if let Some(backslash) = backslash {
+        session
+            .struct_error("unexpected end of file")
+            .span_label(backslash.into(), "after backslash")
+            .emit();
+        has_error = true;
+    }
+
+    if has_error {
+        Err(())
+    } else {
+        Ok(new_tokens)
+    }
+}

--- a/test.c
+++ b/test.c
@@ -3,5 +3,12 @@
 int main() {
 	printf("Hello world");
 
-	return 0;
+	// Single-line comment
+
+	/*
+	 * $$$ test $$$
+	 */
+
+	return \
+		0;
 }


### PR DESCRIPTION
Translation phase 2 is specified as a set of operations on the token stream in the C specification. Translation phase 2 in the spec is described as:
Each instance of a backslash character ( \) immediately followed by a new-line
character is deleted, splicing physical source lines to form logical source lines.
Only the last backslash on any physical source line shall be eligible for being part
of such a splice. A source file that is not empty shall end in a new-line character,
which shall not be immediately preceded by a backslash character before any such
splicing takes place.

In our phase 2, we also remove single-line comments, while multi-line comments are removed during the lexing stage.